### PR TITLE
Remove duplicated text from SHRINE partner description

### DIFF
--- a/app/views/static/partners.html.haml
+++ b/app/views/static/partners.html.haml
@@ -52,7 +52,7 @@
       .col-md-8.pull-right
         %h5.darker-blue Shared Health Research Information Network
         %h5.f300
-          The Shared Health Research Information Network (SHRINE) helps researchers overcome one of the greatest problems in population-based research: compiling large groups of well-characterized patients. Eligible investigators may use the SHRINE web-based query tool to determine the aggregate total number of patients at participating hospitals who meet a given set of inclusion and exclusion criteria (currently demographics, diagnoses, medications, and selected laboratory values).ordinates the A.W.A.K.E. Network of voluntary support groups, and promotes research and continuous improvement of care.
+          The Shared Health Research Information Network (SHRINE) helps researchers overcome one of the greatest problems in population-based research: compiling large groups of well-characterized patients. Eligible investigators may use the SHRINE web-based query tool to determine the aggregate total number of patients at participating hospitals who meet a given set of inclusion and exclusion criteria (currently demographics, diagnoses, medications, and selected laboratory values).
     .row
       .col-md-8
         %h5.darker-blue Informatics for Integrating Biology and the Bedside


### PR DESCRIPTION
The SHRINE copy on `/partners` contained some copy/pasted bits of text from the ASAA partner description. I have removed the text.