### PR TITLE
Remove 'the' from description of PAP device

### DIFF
--- a/app/views/static/PAP.html.haml
+++ b/app/views/static/PAP.html.haml
@@ -5,7 +5,7 @@
 .panel
   .panel-body
     %p.lead
-      Positive Airway Pressure (PAP) therapy is the most common treatment for sleep apnea. When using PAP, you wear a small mask that is attached to a lightweight hose. The hose attaches to a small machine responsible for creating the air pressure. This machine is the PAP device.
+      Positive Airway Pressure (PAP) therapy is the most common treatment for sleep apnea. When using PAP, you wear a small mask that is attached to a lightweight hose. The hose attaches to a small machine responsible for creating air pressure. This machine is the PAP device.
     %p.lead
       Learn more about these devices by visiting the informational pages below.
     .list-group-item


### PR DESCRIPTION
"The" seems irrelevant in this sentence.