### PR TITLE
Tweak disclaimer under promotional partners list

### DIFF
--- a/app/views/static/partners.html.haml
+++ b/app/views/static/partners.html.haml
@@ -70,5 +70,5 @@
   .panel-footer
     %p.small
       *Our promotional and other partners DO NOT have access to your contact or health information.  Per our
-      = link_to 'privacy policy', privacy_path
-      , MyApnea.Org will never share your contact or identifiable health information with any partners or other organizations without your expressed consent.  All members of the network DO have access to de-identified aggregate data as a whole.
+      = link_to('privacy policy', privacy_path) + ','
+      MyApnea.Org will never share your contact or identifiable health information with any partners or other organizations without your express consent.  All members of the network DO have access to de-identified aggregate data.


### PR DESCRIPTION
Fix space between `privacy policy` and comma, along with fixing `expressed` to `express` and removing extraneous phrase.